### PR TITLE
Fix list literal remove behavior and allow empty list

### DIFF
--- a/definy-ui/src/expression_editor.rs
+++ b/definy-ui/src/expression_editor.rs
@@ -1304,7 +1304,7 @@ fn remove_list_item_button(path: Vec<PathStep>, item_index: usize, target: Edito
                 }));
             }
         }))
-        .children([text("Remove")])
+        .children([text("x")])
         .into_node()
 }
 
@@ -1529,9 +1529,6 @@ fn remove_list_item(
     if let Some(definy_event::event::Expression::ListLiteral(list_expr)) =
         get_mut_expression_at_path(root_expression, path)
     {
-        if list_expr.items.len() <= 1 {
-            return;
-        }
         if item_index < list_expr.items.len() {
             list_expr.items.remove(item_index);
         }
@@ -1582,7 +1579,7 @@ fn next_local_variable_id(expression: &definy_event::event::Expression) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{get_mut_expression_at_path, path_to_key, set_number_value, PathStep};
+    use super::{get_mut_expression_at_path, path_to_key, remove_list_item, set_number_value, PathStep};
 
     #[test]
     fn edit_nested_expression_by_ui_path() {
@@ -1616,5 +1613,26 @@ mod tests {
         );
         assert_eq!(path_to_key(&[]), "root");
         assert!(get_mut_expression_at_path(&mut expression, &[PathStep::Left]).is_some());
+    }
+
+    #[test]
+    fn remove_list_item_can_make_empty_and_removes_target_index() {
+        let mut expression =
+            definy_event::event::Expression::ListLiteral(definy_event::event::ListLiteralExpression {
+                items: vec![
+                    definy_event::event::Expression::String(definy_event::event::StringExpression {
+                        value: "a".into(),
+                    }),
+                    definy_event::event::Expression::String(definy_event::event::StringExpression {
+                        value: "b".into(),
+                    }),
+                ],
+            });
+
+        remove_list_item(&mut expression, &[], 0);
+        assert_eq!(crate::expression_eval::expression_to_source(&expression), "[\"b\"]");
+
+        remove_list_item(&mut expression, &[], 0);
+        assert_eq!(crate::expression_eval::expression_to_source(&expression), "[]");
     }
 }

--- a/narumincho-vdom-client/Cargo.toml
+++ b/narumincho-vdom-client/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 narumincho-vdom = { path = "../narumincho-vdom" }
 js-sys = "0.3"
 wasm-bindgen = "0.2"
-web-sys = { version = "0.3.85", features = ["console", "Window", "Document", "Element", "Node", "NodeList", "HtmlElement", "Text", "EventTarget", "Event", "CssStyleDeclaration", "MouseEvent", "PopStateEvent", "History", "Location"] }
+web-sys = { version = "0.3.85", features = ["console", "Window", "Document", "Element", "Node", "NodeList", "HtmlElement", "HtmlInputElement", "Text", "EventTarget", "Event", "CssStyleDeclaration", "MouseEvent", "PopStateEvent", "History", "Location"] }
 wasm-bindgen-futures = "0.4.58"

--- a/narumincho-vdom-client/src/lib.rs
+++ b/narumincho-vdom-client/src/lib.rs
@@ -333,6 +333,11 @@ fn apply_patch<State: 'static>(
             if let Some(element) = node.dyn_ref::<web_sys::Element>() {
                 for (key, value) in attrs {
                     element.set_attribute(&key, &value).unwrap();
+                    if key == "value" {
+                        if let Some(input) = element.dyn_ref::<web_sys::HtmlInputElement>() {
+                            input.set_value(value);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #597

## Summary
- allow removing the final item from list literals so `[]` is possible
- change list item remove button label from `Remove` to `x`
- sync input `value` property when updating `value` attribute in vdom patching to avoid stale display after index-shifting removals
- add unit test covering target index removal and empty list transition

## Validation
- `cargo test -p definy-ui expression_editor -- --nocapture`
- `cargo check -p narumincho-vdom-client`
- `cargo run -p definy-build`