### PR TITLE
PartType に Type を追加

### DIFF
--- a/definy-event/src/event.rs
+++ b/definy-event/src/event.rs
@@ -60,6 +60,7 @@ pub enum PartType {
     Number,
     String,
     Boolean,
+    Type,
     List(Box<PartType>),
 }
 

--- a/definy-ui/src/event_detail.rs
+++ b/definy-ui/src/event_detail.rs
@@ -10,6 +10,7 @@ fn part_type_text(part_type: &definy_event::event::PartType) -> String {
         definy_event::event::PartType::Number => "Number".to_string(),
         definy_event::event::PartType::String => "String".to_string(),
         definy_event::event::PartType::Boolean => "Boolean".to_string(),
+        definy_event::event::PartType::Type => "Type".to_string(),
         definy_event::event::PartType::List(item_type) => {
             format!("list<{}>", part_type_text(item_type.as_ref()))
         }

--- a/definy-ui/src/event_list.rs
+++ b/definy-ui/src/event_list.rs
@@ -10,6 +10,7 @@ fn part_type_text(part_type: &definy_event::event::PartType) -> String {
         definy_event::event::PartType::Number => "Number".to_string(),
         definy_event::event::PartType::String => "String".to_string(),
         definy_event::event::PartType::Boolean => "Boolean".to_string(),
+        definy_event::event::PartType::Type => "Type".to_string(),
         definy_event::event::PartType::List(item_type) => {
             format!("list<{}>", part_type_text(item_type.as_ref()))
         }
@@ -473,6 +474,7 @@ fn render_part_type_editor(part_type: &definy_event::event::PartType, depth: usi
         definy_event::event::PartType::Number => "number",
         definy_event::event::PartType::String => "string",
         definy_event::event::PartType::Boolean => "boolean",
+        definy_event::event::PartType::Type => "type",
         definy_event::event::PartType::List(_) => "list",
     };
 
@@ -523,6 +525,10 @@ fn render_part_type_editor(part_type: &definy_event::event::PartType, depth: usi
                 OptionElement::new()
                     .value("boolean")
                     .children([text("Boolean")])
+                    .into_node(),
+                OptionElement::new()
+                    .value("type")
+                    .children([text("Type")])
                     .into_node(),
                 OptionElement::new()
                     .value("list")
@@ -593,6 +599,7 @@ fn next_part_type_from_selected(
     match selected {
         "string" => definy_event::event::PartType::String,
         "boolean" => definy_event::event::PartType::Boolean,
+        "type" => definy_event::event::PartType::Type,
         "list" => match current {
             definy_event::event::PartType::List(item_type) => {
                 definy_event::event::PartType::List(Box::new(item_type.as_ref().clone()))

--- a/definy-ui/src/expression_editor.rs
+++ b/definy-ui/src/expression_editor.rs
@@ -35,6 +35,7 @@ enum ExpressionType {
     Number,
     String,
     Boolean,
+    Type,
     List(Box<ExpressionType>),
     Record,
     Unknown,
@@ -46,6 +47,7 @@ impl ExpressionType {
             ExpressionType::Number => "Number".to_string(),
             ExpressionType::String => "String".to_string(),
             ExpressionType::Boolean => "Boolean".to_string(),
+            ExpressionType::Type => "Type".to_string(),
             ExpressionType::List(item) => format!("list<{}>", item.text()),
             ExpressionType::Record => "Record".to_string(),
             ExpressionType::Unknown => "Unknown".to_string(),
@@ -498,6 +500,7 @@ fn part_type_to_expression_type(part_type: &definy_event::event::PartType) -> Ex
         definy_event::event::PartType::Number => ExpressionType::Number,
         definy_event::event::PartType::String => ExpressionType::String,
         definy_event::event::PartType::Boolean => ExpressionType::Boolean,
+        definy_event::event::PartType::Type => ExpressionType::Type,
         definy_event::event::PartType::List(item_type) => {
             ExpressionType::List(Box::new(part_type_to_expression_type(item_type.as_ref())))
         }

--- a/definy-ui/src/part_list.rs
+++ b/definy-ui/src/part_list.rs
@@ -10,6 +10,7 @@ fn part_type_text(part_type: &definy_event::event::PartType) -> String {
         definy_event::event::PartType::Number => "Number".to_string(),
         definy_event::event::PartType::String => "String".to_string(),
         definy_event::event::PartType::Boolean => "Boolean".to_string(),
+        definy_event::event::PartType::Type => "Type".to_string(),
         definy_event::event::PartType::List(item_type) => {
             format!("list<{}>", part_type_text(item_type.as_ref()))
         }


### PR DESCRIPTION
## Summary
- `PartType` に `Type` バリアントを追加
- パーツ作成フォームの型選択に `Type` を追加
- イベント/パーツ表示と型診断の表示に `Type` を反映

## Verification
- `cargo check`

Closes #599