### PR TITLE
Allow PartDefinition part_type to be optional

### DIFF
--- a/definy-client/src/lib.rs
+++ b/definy-client/src/lib.rs
@@ -72,15 +72,19 @@ impl narumincho_vdom_client::App<AppState> for DefinyApp {
             current_key: None,
             part_definition_form: definy_ui::PartDefinitionFormState {
                 part_name_input: String::new(),
-                part_type_input: definy_event::event::PartType::Number,
+                part_type_input: Some(definy_event::event::PartType::Number),
                 part_description_input: String::new(),
-                composing_expression: definy_event::event::Expression::Number(definy_event::event::NumberExpression { value: 0 }),
+                composing_expression: definy_event::event::Expression::Number(
+                    definy_event::event::NumberExpression { value: 0 },
+                ),
                 eval_result: None,
             },
             part_update_form: definy_ui::PartUpdateFormState {
                 part_name_input: String::new(),
                 part_description_input: String::new(),
-                expression_input: definy_event::event::Expression::Number(definy_event::event::NumberExpression { value: 0 }),
+                expression_input: definy_event::event::Expression::Number(
+                    definy_event::event::NumberExpression { value: 0 },
+                ),
             },
             event_detail_eval_result: None,
             profile_name_input: String::new(),

--- a/definy-event/src/event.rs
+++ b/definy-event/src/event.rs
@@ -30,8 +30,8 @@ pub enum EventContent {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PartDefinitionEvent {
     pub part_name: Box<str>,
-    #[serde(default = "default_part_type")]
-    pub part_type: PartType,
+    #[serde(default)]
+    pub part_type: Option<PartType>,
     #[serde(default)]
     pub description: Box<str>,
     pub expression: Expression,
@@ -48,10 +48,6 @@ pub struct PartUpdateEvent {
 
 fn default_expression() -> Expression {
     Expression::Number(NumberExpression { value: 0 })
-}
-
-fn default_part_type() -> PartType {
-    PartType::Number
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/definy-server/src/main.rs
+++ b/definy-server/src/main.rs
@@ -245,7 +245,7 @@ async fn handle_html(
                     current_key: None,
                     part_definition_form: definy_ui::PartDefinitionFormState {
                         part_name_input: String::new(),
-                        part_type_input: definy_event::event::PartType::Number,
+                        part_type_input: Some(definy_event::event::PartType::Number),
                         part_description_input: String::new(),
                         composing_expression: definy_event::event::Expression::Number(
                             definy_event::event::NumberExpression { value: 0 },

--- a/definy-ui/src/app_state.rs
+++ b/definy-ui/src/app_state.rs
@@ -22,7 +22,7 @@ pub struct AppState {
 #[derive(Clone)]
 pub struct PartDefinitionFormState {
     pub part_name_input: String,
-    pub part_type_input: definy_event::event::PartType,
+    pub part_type_input: Option<definy_event::event::PartType>,
     pub part_description_input: String,
     pub composing_expression: definy_event::event::Expression,
     pub eval_result: Option<String>,

--- a/definy-ui/src/event_detail.rs
+++ b/definy-ui/src/event_detail.rs
@@ -17,6 +17,13 @@ fn part_type_text(part_type: &definy_event::event::PartType) -> String {
     }
 }
 
+fn optional_part_type_text(part_type: &Option<definy_event::event::PartType>) -> String {
+    part_type
+        .as_ref()
+        .map(part_type_text)
+        .unwrap_or_else(|| "None".to_string())
+}
+
 pub fn event_detail_view(state: &AppState, target_hash: &[u8; 32]) -> Node<AppState> {
     let account_name_map = state.account_name_map();
     let mut target_event_opt = None;
@@ -172,7 +179,7 @@ fn render_event_detail(
                         text(format!(
                             "{}: {} = {}",
                             part_definition_event.part_name,
-                            part_type_text(&part_definition_event.part_type),
+                            optional_part_type_text(&part_definition_event.part_type),
                             expression_to_source(&part_definition_event.expression)
                         )),
                         if part_definition_event.description.is_empty() {

--- a/definy-ui/src/event_list.rs
+++ b/definy-ui/src/event_list.rs
@@ -17,6 +17,13 @@ fn part_type_text(part_type: &definy_event::event::PartType) -> String {
     }
 }
 
+fn optional_part_type_text(part_type: &Option<definy_event::event::PartType>) -> String {
+    part_type
+        .as_ref()
+        .map(part_type_text)
+        .unwrap_or_else(|| "None".to_string())
+}
+
 pub fn event_list_view(state: &AppState) -> Node<AppState> {
     let part_definition_form = if state.current_key.is_some() {
         Some(
@@ -153,7 +160,7 @@ pub fn event_list_view(state: &AppState) -> Node<AppState> {
                                         let mut next = state.clone();
                                         next.part_definition_form.part_name_input = String::new();
                                         next.part_definition_form.part_type_input =
-                                            definy_event::event::PartType::Number;
+                                            Some(definy_event::event::PartType::Number);
                                         next.part_definition_form.part_description_input = String::new();
                                         next.part_definition_form.eval_result = None;
                                         next.part_definition_form.composing_expression =
@@ -303,7 +310,7 @@ fn event_view(
                             text(format!(
                                 "{}: {} = {}",
                                 part_definition_event.part_name,
-                                part_type_text(&part_definition_event.part_type),
+                                optional_part_type_text(&part_definition_event.part_type),
                                 expression_to_source(&part_definition_event.expression)
                             )),
                             if part_definition_event.description.is_empty() {
@@ -467,15 +474,19 @@ fn part_type_input(state: &AppState) -> Node<AppState> {
         .into_node()
 }
 
-fn render_part_type_editor(part_type: &definy_event::event::PartType, depth: usize) -> Node<AppState> {
+fn render_part_type_editor(
+    part_type: &Option<definy_event::event::PartType>,
+    depth: usize,
+) -> Node<AppState> {
     let name = format!("part-definition-type-{}", depth);
     let selector = format!("select[name='{}']", name);
     let selected = match part_type {
-        definy_event::event::PartType::Number => "number",
-        definy_event::event::PartType::String => "string",
-        definy_event::event::PartType::Boolean => "boolean",
-        definy_event::event::PartType::Type => "type",
-        definy_event::event::PartType::List(_) => "list",
+        None => "none",
+        Some(definy_event::event::PartType::Number) => "number",
+        Some(definy_event::event::PartType::String) => "string",
+        Some(definy_event::event::PartType::Boolean) => "boolean",
+        Some(definy_event::event::PartType::Type) => "type",
+        Some(definy_event::event::PartType::List(_)) => "list",
     };
 
     let mut select = Select::new()
@@ -493,7 +504,8 @@ fn render_part_type_editor(part_type: &definy_event::event::PartType, depth: usi
                     .and_then(|document| document.query_selector(selector.as_str()).ok())
                     .flatten()
                     .and_then(|element| {
-                        js_sys::Reflect::get(&element, &wasm_bindgen::JsValue::from_str("value")).ok()
+                        js_sys::Reflect::get(&element, &wasm_bindgen::JsValue::from_str("value"))
+                            .ok()
                     })
                     .and_then(|value| value.as_string())
                     .unwrap_or_else(|| "number".to_string());
@@ -511,34 +523,42 @@ fn render_part_type_editor(part_type: &definy_event::event::PartType, depth: usi
         }),
     ));
 
-    let mut children = vec![
-        select
-            .children([
-                OptionElement::new()
-                    .value("number")
-                    .children([text("Number")])
-                    .into_node(),
-                OptionElement::new()
-                    .value("string")
-                    .children([text("String")])
-                    .into_node(),
-                OptionElement::new()
-                    .value("boolean")
-                    .children([text("Boolean")])
-                    .into_node(),
-                OptionElement::new()
-                    .value("type")
-                    .children([text("Type")])
-                    .into_node(),
-                OptionElement::new()
-                    .value("list")
-                    .children([text("List<...>")])
-                    .into_node(),
-            ])
-            .into_node(),
-    ];
+    let mut options = Vec::new();
+    if depth == 0 {
+        options.push(
+            OptionElement::new()
+                .value("none")
+                .children([text("None")])
+                .into_node(),
+        );
+    }
 
-    if let definy_event::event::PartType::List(item_type) = part_type {
+    options.extend([
+        OptionElement::new()
+            .value("number")
+            .children([text("Number")])
+            .into_node(),
+        OptionElement::new()
+            .value("string")
+            .children([text("String")])
+            .into_node(),
+        OptionElement::new()
+            .value("boolean")
+            .children([text("Boolean")])
+            .into_node(),
+        OptionElement::new()
+            .value("type")
+            .children([text("Type")])
+            .into_node(),
+        OptionElement::new()
+            .value("list")
+            .children([text("List<...>")])
+            .into_node(),
+    ]);
+
+    let mut children = vec![select.children(options).into_node()];
+
+    if let Some(definy_event::event::PartType::List(item_type)) = part_type {
         children.push(
             Div::new()
                 .style(
@@ -556,7 +576,7 @@ fn render_part_type_editor(part_type: &definy_event::event::PartType, depth: usi
                         )
                         .children([text("Item Type")])
                         .into_node(),
-                    render_part_type_editor(item_type.as_ref(), depth + 1),
+                    render_part_type_editor(&Some(item_type.as_ref().clone()), depth + 1),
                 ])
                 .into_node(),
         );
@@ -569,7 +589,7 @@ fn render_part_type_editor(part_type: &definy_event::event::PartType, depth: usi
 }
 
 fn update_part_type_at_depth(
-    part_type: &mut definy_event::event::PartType,
+    part_type: &mut Option<definy_event::event::PartType>,
     depth: usize,
     selected: &str,
 ) {
@@ -579,20 +599,67 @@ fn update_part_type_at_depth(
     }
 
     match part_type {
-        definy_event::event::PartType::List(item_type) => {
-            update_part_type_at_depth(item_type.as_mut(), depth - 1, selected);
+        Some(definy_event::event::PartType::List(item_type)) => {
+            update_part_type_nested(item_type.as_mut(), depth - 1, selected);
         }
         _ => {
-            *part_type =
-                definy_event::event::PartType::List(Box::new(definy_event::event::PartType::Number));
+            *part_type = Some(definy_event::event::PartType::List(Box::new(
+                definy_event::event::PartType::Number,
+            )));
+            if let Some(definy_event::event::PartType::List(item_type)) = part_type {
+                update_part_type_nested(item_type.as_mut(), depth - 1, selected);
+            }
+        }
+    }
+}
+
+fn update_part_type_nested(
+    part_type: &mut definy_event::event::PartType,
+    depth: usize,
+    selected: &str,
+) {
+    if depth == 0 {
+        *part_type = next_nested_part_type_from_selected(selected, part_type);
+        return;
+    }
+
+    match part_type {
+        definy_event::event::PartType::List(item_type) => {
+            update_part_type_nested(item_type.as_mut(), depth - 1, selected);
+        }
+        _ => {
+            *part_type = definy_event::event::PartType::List(Box::new(
+                definy_event::event::PartType::Number,
+            ));
             if let definy_event::event::PartType::List(item_type) = part_type {
-                update_part_type_at_depth(item_type.as_mut(), depth - 1, selected);
+                update_part_type_nested(item_type.as_mut(), depth - 1, selected);
             }
         }
     }
 }
 
 fn next_part_type_from_selected(
+    selected: &str,
+    current: &Option<definy_event::event::PartType>,
+) -> Option<definy_event::event::PartType> {
+    match selected {
+        "none" => None,
+        "string" => Some(definy_event::event::PartType::String),
+        "boolean" => Some(definy_event::event::PartType::Boolean),
+        "type" => Some(definy_event::event::PartType::Type),
+        "list" => match current {
+            Some(definy_event::event::PartType::List(item_type)) => Some(
+                definy_event::event::PartType::List(Box::new(item_type.as_ref().clone())),
+            ),
+            _ => Some(definy_event::event::PartType::List(Box::new(
+                definy_event::event::PartType::Number,
+            ))),
+        },
+        _ => Some(definy_event::event::PartType::Number),
+    }
+}
+
+fn next_nested_part_type_from_selected(
     selected: &str,
     current: &definy_event::event::PartType,
 ) -> definy_event::event::PartType {
@@ -604,7 +671,9 @@ fn next_part_type_from_selected(
             definy_event::event::PartType::List(item_type) => {
                 definy_event::event::PartType::List(Box::new(item_type.as_ref().clone()))
             }
-            _ => definy_event::event::PartType::List(Box::new(definy_event::event::PartType::Number)),
+            _ => {
+                definy_event::event::PartType::List(Box::new(definy_event::event::PartType::Number))
+            }
         },
         _ => definy_event::event::PartType::Number,
     }

--- a/definy-ui/src/expression_editor.rs
+++ b/definy-ui/src/expression_editor.rs
@@ -1,9 +1,9 @@
 use narumincho_vdom::*;
 use std::collections::HashMap;
 
+use crate::Location;
 use crate::app_state::AppState;
 use crate::part_projection::{collect_part_snapshots, find_part_snapshot};
-use crate::Location;
 
 #[derive(Clone, Copy)]
 pub enum EditorTarget {
@@ -93,14 +93,12 @@ fn render_expression_editor(
         .find(|diagnostic| diagnostic.path == path)
         .map(|diagnostic| diagnostic.message.as_str());
 
-    let mut children = vec![
-        expression_selector(
-            path.clone(),
-            target,
-            &current_selection,
-            &selector_options,
-        ),
-    ];
+    let mut children = vec![expression_selector(
+        path.clone(),
+        target,
+        &current_selection,
+        &selector_options,
+    )];
     if let Some(warning_message) = warning_message {
         children.push(
             Div::new()
@@ -372,24 +370,21 @@ fn render_expression_editor(
                             .into_node(),
                         Div::new()
                             .style(Style::new().set("display", "grid").set("gap", "0.3rem"))
-                            .children([
-                                text("Body"),
-                                {
-                                    let mut body_scope = scope_variables.clone();
-                                    body_scope.push(ScopeVariable {
-                                        id: let_expression.variable_id,
-                                        name: let_expression.variable_name.to_string(),
-                                    });
-                                    render_expression_editor(
-                                        state,
-                                        let_expression.body.as_ref(),
-                                        body_path,
-                                        target,
-                                        body_scope,
-                                        diagnostics,
-                                    )
-                                },
-                            ])
+                            .children([text("Body"), {
+                                let mut body_scope = scope_variables.clone();
+                                body_scope.push(ScopeVariable {
+                                    id: let_expression.variable_id,
+                                    name: let_expression.variable_name.to_string(),
+                                });
+                                render_expression_editor(
+                                    state,
+                                    let_expression.body.as_ref(),
+                                    body_path,
+                                    target,
+                                    body_scope,
+                                    diagnostics,
+                                )
+                            }])
                             .into_node(),
                     ])
                     .into_node(),
@@ -430,7 +425,12 @@ fn render_expression_editor(
                                         )
                                         .children([text("Key")])
                                         .into_node(),
-                                    record_item_key_input(path.clone(), index, target, item.key.as_ref()),
+                                    record_item_key_input(
+                                        path.clone(),
+                                        index,
+                                        target,
+                                        item.key.as_ref(),
+                                    ),
                                     remove_record_item_button(path.clone(), index, target),
                                 ])
                                 .into_node(),
@@ -509,9 +509,11 @@ fn part_type_to_expression_type(part_type: &definy_event::event::PartType) -> Ex
 
 fn expected_type_for_target(state: &AppState, target: EditorTarget) -> Option<ExpressionType> {
     match target {
-        EditorTarget::PartDefinition => Some(part_type_to_expression_type(
-            &state.part_definition_form.part_type_input,
-        )),
+        EditorTarget::PartDefinition => state
+            .part_definition_form
+            .part_type_input
+            .as_ref()
+            .map(part_type_to_expression_type),
         EditorTarget::PartUpdate => {
             let hash = match state.location {
                 Some(Location::Part(hash)) => hash,
@@ -533,10 +535,12 @@ fn collect_type_diagnostics(
     let part_type_map = collect_part_snapshots(state)
         .into_iter()
         .filter_map(|snapshot| {
-            snapshot
-                .part_type
-                .as_ref()
-                .map(|part_type| (snapshot.definition_event_hash, part_type_to_expression_type(part_type)))
+            snapshot.part_type.as_ref().map(|part_type| {
+                (
+                    snapshot.definition_event_hash,
+                    part_type_to_expression_type(part_type),
+                )
+            })
         })
         .collect::<HashMap<[u8; 32], ExpressionType>>();
 
@@ -585,11 +589,12 @@ fn check_expression_type(
         definy_event::event::Expression::String(_) => ExpressionType::String,
         definy_event::event::Expression::Boolean(_) => ExpressionType::Boolean,
         definy_event::event::Expression::ListLiteral(list_expression) => {
-            let expected_item_type = if let Some(ExpressionType::List(item_type)) = expected_type.as_ref() {
-                Some(item_type.as_ref().clone())
-            } else {
-                None
-            };
+            let expected_item_type =
+                if let Some(ExpressionType::List(item_type)) = expected_type.as_ref() {
+                    Some(item_type.as_ref().clone())
+                } else {
+                    None
+                };
             let mut inferred_item_type = expected_item_type.clone();
             for (index, item) in list_expression.items.iter().enumerate() {
                 let mut item_path = path.to_vec();
@@ -806,11 +811,8 @@ fn expression_selector(
                     .and_then(|document| document.query_selector(selector.as_str()).ok())
                     .flatten()
                     .and_then(|element| {
-                        js_sys::Reflect::get(
-                            &element,
-                            &wasm_bindgen::JsValue::from_str("value"),
-                        )
-                        .ok()
+                        js_sys::Reflect::get(&element, &wasm_bindgen::JsValue::from_str("value"))
+                            .ok()
                     })
                     .and_then(|value| value.as_string())
                     .unwrap_or_default();
@@ -910,7 +912,9 @@ fn apply_selection(
     };
     if let Some(expression) = get_mut_expression_at_path(root_expression, path) {
         *expression = if selected_value == "expr:number" {
-            definy_event::event::Expression::Number(definy_event::event::NumberExpression { value: 0 })
+            definy_event::event::Expression::Number(definy_event::event::NumberExpression {
+                value: 0,
+            })
         } else if selected_value == "expr:string" {
             definy_event::event::Expression::String(definy_event::event::StringExpression {
                 value: "".into(),
@@ -1257,7 +1261,11 @@ fn add_record_item_button(path: Vec<PathStep>, target: EditorTarget) -> Node<App
         .into_node()
 }
 
-fn remove_record_item_button(path: Vec<PathStep>, item_index: usize, target: EditorTarget) -> Node<AppState> {
+fn remove_record_item_button(
+    path: Vec<PathStep>,
+    item_index: usize,
+    target: EditorTarget,
+) -> Node<AppState> {
     Button::new()
         .type_("button")
         .on_click(EventHandler::new(move |set_state| {
@@ -1293,7 +1301,11 @@ fn add_list_item_button(path: Vec<PathStep>, target: EditorTarget) -> Node<AppSt
         .into_node()
 }
 
-fn remove_list_item_button(path: Vec<PathStep>, item_index: usize, target: EditorTarget) -> Node<AppState> {
+fn remove_list_item_button(
+    path: Vec<PathStep>,
+    item_index: usize,
+    target: EditorTarget,
+) -> Node<AppState> {
     Button::new()
         .type_("button")
         .on_click(EventHandler::new(move |set_state| {
@@ -1488,12 +1500,14 @@ fn add_record_item(root_expression: &mut definy_event::event::Expression, path: 
     if let Some(definy_event::event::Expression::RecordLiteral(record_expr)) =
         get_mut_expression_at_path(root_expression, path)
     {
-        record_expr.items.push(definy_event::event::RecordItemExpression {
-            key: format!("key{}", record_expr.items.len() + 1).into(),
-            value: Box::new(definy_event::event::Expression::Number(
-                definy_event::event::NumberExpression { value: 0 },
-            )),
-        });
+        record_expr
+            .items
+            .push(definy_event::event::RecordItemExpression {
+                key: format!("key{}", record_expr.items.len() + 1).into(),
+                value: Box::new(definy_event::event::Expression::Number(
+                    definy_event::event::NumberExpression { value: 0 },
+                )),
+            });
     }
 }
 
@@ -1518,9 +1532,11 @@ fn add_list_item(root_expression: &mut definy_event::event::Expression, path: &[
     if let Some(definy_event::event::Expression::ListLiteral(list_expr)) =
         get_mut_expression_at_path(root_expression, path)
     {
-        list_expr.items.push(definy_event::event::Expression::Number(
-            definy_event::event::NumberExpression { value: 0 },
-        ));
+        list_expr
+            .items
+            .push(definy_event::event::Expression::Number(
+                definy_event::event::NumberExpression { value: 0 },
+            ));
     }
 }
 
@@ -1582,25 +1598,28 @@ fn next_local_variable_id(expression: &definy_event::event::Expression) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{get_mut_expression_at_path, path_to_key, remove_list_item, set_number_value, PathStep};
+    use super::{
+        PathStep, get_mut_expression_at_path, path_to_key, remove_list_item, set_number_value,
+    };
 
     #[test]
     fn edit_nested_expression_by_ui_path() {
-        let mut expression = definy_event::event::Expression::Add(definy_event::event::AddExpression {
-            left: Box::new(definy_event::event::Expression::Number(
-                definy_event::event::NumberExpression { value: 0 },
-            )),
-            right: Box::new(definy_event::event::Expression::Add(
-                definy_event::event::AddExpression {
-                    left: Box::new(definy_event::event::Expression::Number(
-                        definy_event::event::NumberExpression { value: 0 },
-                    )),
-                    right: Box::new(definy_event::event::Expression::Number(
-                        definy_event::event::NumberExpression { value: 0 },
-                    )),
-                },
-            )),
-        });
+        let mut expression =
+            definy_event::event::Expression::Add(definy_event::event::AddExpression {
+                left: Box::new(definy_event::event::Expression::Number(
+                    definy_event::event::NumberExpression { value: 0 },
+                )),
+                right: Box::new(definy_event::event::Expression::Add(
+                    definy_event::event::AddExpression {
+                        left: Box::new(definy_event::event::Expression::Number(
+                            definy_event::event::NumberExpression { value: 0 },
+                        )),
+                        right: Box::new(definy_event::event::Expression::Number(
+                            definy_event::event::NumberExpression { value: 0 },
+                        )),
+                    },
+                )),
+            });
 
         set_number_value(&mut expression, &[PathStep::Left], 321);
         set_number_value(&mut expression, &[PathStep::Right, PathStep::Left], 1);
@@ -1620,22 +1639,29 @@ mod tests {
 
     #[test]
     fn remove_list_item_can_make_empty_and_removes_target_index() {
-        let mut expression =
-            definy_event::event::Expression::ListLiteral(definy_event::event::ListLiteralExpression {
+        let mut expression = definy_event::event::Expression::ListLiteral(
+            definy_event::event::ListLiteralExpression {
                 items: vec![
-                    definy_event::event::Expression::String(definy_event::event::StringExpression {
-                        value: "a".into(),
-                    }),
-                    definy_event::event::Expression::String(definy_event::event::StringExpression {
-                        value: "b".into(),
-                    }),
+                    definy_event::event::Expression::String(
+                        definy_event::event::StringExpression { value: "a".into() },
+                    ),
+                    definy_event::event::Expression::String(
+                        definy_event::event::StringExpression { value: "b".into() },
+                    ),
                 ],
-            });
+            },
+        );
 
         remove_list_item(&mut expression, &[], 0);
-        assert_eq!(crate::expression_eval::expression_to_source(&expression), "[\"b\"]");
+        assert_eq!(
+            crate::expression_eval::expression_to_source(&expression),
+            "[\"b\"]"
+        );
 
         remove_list_item(&mut expression, &[], 0);
-        assert_eq!(crate::expression_eval::expression_to_source(&expression), "[]");
+        assert_eq!(
+            crate::expression_eval::expression_to_source(&expression),
+            "[]"
+        );
     }
 }

--- a/definy-ui/src/expression_eval.rs
+++ b/definy-ui/src/expression_eval.rs
@@ -119,10 +119,9 @@ fn evaluate_via_wasm(
 fn has_part_references(expr: &definy_event::event::Expression) -> bool {
     match expr {
         definy_event::event::Expression::PartReference(_) => true,
-        definy_event::event::Expression::ListLiteral(list_expression) => list_expression
-            .items
-            .iter()
-            .any(has_part_references),
+        definy_event::event::Expression::ListLiteral(list_expression) => {
+            list_expression.items.iter().any(has_part_references)
+        }
         definy_event::event::Expression::Add(a) => {
             has_part_references(&a.left) || has_part_references(&a.right)
         }
@@ -382,7 +381,9 @@ pub fn expression_to_source(expression: &definy_event::event::Expression) -> Str
                 }
             }
             definy_event::event::Expression::PartReference(part_reference_expression) => {
-                crate::hash_format::encode_hash32(&part_reference_expression.part_definition_event_hash)
+                crate::hash_format::encode_hash32(
+                    &part_reference_expression.part_definition_event_hash,
+                )
             }
             definy_event::event::Expression::Let(let_expression) => {
                 let mut body_scope = scope.to_vec();
@@ -402,24 +403,28 @@ pub fn expression_to_source(expression: &definy_event::event::Expression) -> Str
                     source
                 }
             }
-            definy_event::event::Expression::Variable(variable_expression) => {
-                scope
-                    .iter()
-                    .rev()
-                    .find_map(|(id, name)| {
-                        if *id == variable_expression.variable_id {
-                            Some(name.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap_or_else(|| format!("#{}", variable_expression.variable_id))
-            }
+            definy_event::event::Expression::Variable(variable_expression) => scope
+                .iter()
+                .rev()
+                .find_map(|(id, name)| {
+                    if *id == variable_expression.variable_id {
+                        Some(name.clone())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| format!("#{}", variable_expression.variable_id)),
             definy_event::event::Expression::RecordLiteral(record_expression) => {
                 let items = record_expression
                     .items
                     .iter()
-                    .map(|item| format!("{}: {}", item.key, render(item.value.as_ref(), false, scope)))
+                    .map(|item| {
+                        format!(
+                            "{}: {}",
+                            item.key,
+                            render(item.value.as_ref(), false, scope)
+                        )
+                    })
                     .collect::<Vec<String>>()
                     .join(", ");
                 format!("{{{}}}", items)
@@ -588,8 +593,8 @@ mod tests {
 
     #[test]
     fn evaluate_list_literal() {
-        let list_expr =
-            definy_event::event::Expression::ListLiteral(definy_event::event::ListLiteralExpression {
+        let list_expr = definy_event::event::Expression::ListLiteral(
+            definy_event::event::ListLiteralExpression {
                 items: vec![
                     definy_event::event::Expression::Number(
                         definy_event::event::NumberExpression { value: 1 },
@@ -598,7 +603,8 @@ mod tests {
                         definy_event::event::NumberExpression { value: 2 },
                     ),
                 ],
-            });
+            },
+        );
         assert_eq!(
             evaluate_expression(&list_expr, &[]),
             Ok(crate::expression_eval::Value::List(vec![
@@ -652,11 +658,17 @@ mod tests {
         assert_eq!(
             evaluate_expression(&record_expr, &[]),
             Ok(crate::expression_eval::Value::Record(vec![
-                ("name".to_string(), crate::expression_eval::Value::String("narumi".to_string())),
+                (
+                    "name".to_string(),
+                    crate::expression_eval::Value::String("narumi".to_string())
+                ),
                 ("age".to_string(), crate::expression_eval::Value::Number(3)),
             ]))
         );
-        assert_eq!(expression_to_source(&record_expr), "{name: \"narumi\", age: 3}");
+        assert_eq!(
+            expression_to_source(&record_expr),
+            "{name: \"narumi\", age: 3}"
+        );
     }
 
     #[test]
@@ -678,14 +690,10 @@ mod tests {
                     body: Box::new(definy_event::event::Expression::Add(
                         definy_event::event::AddExpression {
                             left: Box::new(definy_event::event::Expression::Variable(
-                                definy_event::event::VariableExpression {
-                                    variable_id: 1,
-                                },
+                                definy_event::event::VariableExpression { variable_id: 1 },
                             )),
                             right: Box::new(definy_event::event::Expression::Variable(
-                                definy_event::event::VariableExpression {
-                                    variable_id: 2,
-                                },
+                                definy_event::event::VariableExpression { variable_id: 2 },
                             )),
                         },
                     )),
@@ -716,7 +724,7 @@ mod tests {
                     content: definy_event::event::EventContent::PartDefinition(
                         definy_event::event::PartDefinitionEvent {
                             part_name: "legacy-name".into(),
-                            part_type: definy_event::event::PartType::Number,
+                            part_type: Some(definy_event::event::PartType::Number),
                             description: "".into(),
                             expression: part_expression,
                         },

--- a/definy-ui/src/part_list.rs
+++ b/definy-ui/src/part_list.rs
@@ -1,9 +1,9 @@
 use narumincho_vdom::*;
 
+use crate::Location;
 use crate::app_state::AppState;
 use crate::expression_eval::expression_to_source;
 use crate::part_projection::collect_part_snapshots;
-use crate::Location;
 
 fn part_type_text(part_type: &definy_event::event::PartType) -> String {
     match part_type {
@@ -15,6 +15,13 @@ fn part_type_text(part_type: &definy_event::event::PartType) -> String {
             format!("list<{}>", part_type_text(item_type.as_ref()))
         }
     }
+}
+
+fn optional_part_type_text(part_type: &Option<definy_event::event::PartType>) -> String {
+    part_type
+        .as_ref()
+        .map(part_type_text)
+        .unwrap_or_else(|| "None".to_string())
 }
 
 pub fn part_list_view(state: &AppState) -> Node<AppState> {
@@ -67,7 +74,9 @@ pub fn part_list_view(state: &AppState) -> Node<AppState> {
                                                     .set("color", "var(--text-secondary)"),
                                             )
                                             .children([text(
-                                                part.updated_at.format("%Y-%m-%d %H:%M:%S").to_string(),
+                                                part.updated_at
+                                                    .format("%Y-%m-%d %H:%M:%S")
+                                                    .to_string(),
                                             )])
                                             .into_node(),
                                         Div::new()
@@ -82,10 +91,7 @@ pub fn part_list_view(state: &AppState) -> Node<AppState> {
                                             )
                                             .children([text(format!(
                                                 "type: {}",
-                                                part.part_type
-                                                    .as_ref()
-                                                    .map(part_type_text)
-                                                    .unwrap_or_else(|| "Unknown".to_string())
+                                                optional_part_type_text(&part.part_type)
                                             ))])
                                             .into_node(),
                                         if part.has_definition {
@@ -136,17 +142,28 @@ pub fn part_list_view(state: &AppState) -> Node<AppState> {
                                                     .set("font-size", "0.85rem")
                                                     .set("color", "var(--primary)"),
                                             )
-                                            .children([text(format!("latest author: {}", account_name))])
+                                            .children([text(format!(
+                                                "latest author: {}",
+                                                account_name
+                                            ))])
                                             .into_node(),
                                         Div::new()
-                                            .style(Style::new().set("display", "flex").set("gap", "0.45rem"))
+                                            .style(
+                                                Style::new()
+                                                    .set("display", "flex")
+                                                    .set("gap", "0.45rem"),
+                                            )
                                             .children([
                                                 A::<AppState, Location>::new()
-                                                    .href(Href::Internal(Location::Event(part.latest_event_hash)))
+                                                    .href(Href::Internal(Location::Event(
+                                                        part.latest_event_hash,
+                                                    )))
                                                     .children([text("Latest event")])
                                                     .into_node(),
                                                 A::<AppState, Location>::new()
-                                                    .href(Href::Internal(Location::Event(part.definition_event_hash)))
+                                                    .href(Href::Internal(Location::Event(
+                                                        part.definition_event_hash,
+                                                    )))
                                                     .children([text("Definition event")])
                                                     .into_node(),
                                             ])

--- a/definy-ui/src/part_projection.rs
+++ b/definy-ui/src/part_projection.rs
@@ -37,7 +37,7 @@ pub fn collect_part_snapshots(state: &AppState) -> Vec<PartSnapshot> {
                         latest_event_hash: event_hash,
                         account_id: event.account_id.clone(),
                         part_name: part_definition.part_name.to_string(),
-                        part_type: Some(part_definition.part_type.clone()),
+                        part_type: part_definition.part_type.clone(),
                         part_description: part_definition.description.to_string(),
                         expression: part_definition.expression.clone(),
                         updated_at: event.time,
@@ -75,7 +75,10 @@ pub fn collect_part_snapshots(state: &AppState) -> Vec<PartSnapshot> {
     snapshots
 }
 
-pub fn find_part_snapshot(state: &AppState, definition_event_hash: &[u8; 32]) -> Option<PartSnapshot> {
+pub fn find_part_snapshot(
+    state: &AppState,
+    definition_event_hash: &[u8; 32],
+) -> Option<PartSnapshot> {
     collect_part_snapshots(state)
         .into_iter()
         .find(|snapshot| &snapshot.definition_event_hash == definition_event_hash)

--- a/definy-ui/tests/browser_e2e.rs
+++ b/definy-ui/tests/browser_e2e.rs
@@ -82,7 +82,11 @@ impl WebDriverClient {
                 let mut chrome_options = serde_json::Map::new();
                 chrome_options.insert(
                     "args".to_string(),
-                    serde_json::json!(["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"]),
+                    serde_json::json!([
+                        "--headless=new",
+                        "--no-sandbox",
+                        "--disable-dev-shm-usage"
+                    ]),
                 );
                 if let Some(binary) = chrome_binary {
                     chrome_options.insert("binary".to_string(), serde_json::json!(binary));
@@ -98,12 +102,17 @@ impl WebDriverClient {
             }
         };
 
-        let response = webdriver_request(&client, &base_url, Method::POST, "/session", Some(caps)).await?;
+        let response =
+            webdriver_request(&client, &base_url, Method::POST, "/session", Some(caps)).await?;
 
         let session_id = response
             .get("value")
             .and_then(|v| v.get("sessionId").and_then(serde_json::Value::as_str))
-            .or_else(|| response.get("sessionId").and_then(serde_json::Value::as_str))
+            .or_else(|| {
+                response
+                    .get("sessionId")
+                    .and_then(serde_json::Value::as_str)
+            })
             .ok_or("failed to create WebDriver session")?
             .to_string();
 
@@ -117,7 +126,14 @@ impl WebDriverClient {
     async fn goto(&self, url: &str) -> Result<(), Box<dyn Error>> {
         let path = format!("/session/{}/url", self.session_id);
         let payload = serde_json::json!({ "url": url });
-        let _ = webdriver_request(&self.client, &self.base_url, Method::POST, &path, Some(payload)).await?;
+        let _ = webdriver_request(
+            &self.client,
+            &self.base_url,
+            Method::POST,
+            &path,
+            Some(payload),
+        )
+        .await?;
         Ok(())
     }
 
@@ -138,7 +154,8 @@ impl WebDriverClient {
     async fn text_of(&self, css_selector: &str) -> Result<String, Box<dyn Error>> {
         let element_id = self.find_element(css_selector).await?;
         let path = format!("/session/{}/element/{}/text", self.session_id, element_id);
-        let response = webdriver_request(&self.client, &self.base_url, Method::GET, &path, None).await?;
+        let response =
+            webdriver_request(&self.client, &self.base_url, Method::GET, &path, None).await?;
         let text = response
             .get("value")
             .and_then(serde_json::Value::as_str)
@@ -165,7 +182,8 @@ impl WebDriverClient {
 
     async fn current_url(&self) -> Result<String, Box<dyn Error>> {
         let path = format!("/session/{}/url", self.session_id);
-        let response = webdriver_request(&self.client, &self.base_url, Method::GET, &path, None).await?;
+        let response =
+            webdriver_request(&self.client, &self.base_url, Method::GET, &path, None).await?;
         let current = response
             .get("value")
             .and_then(serde_json::Value::as_str)
@@ -314,15 +332,19 @@ fn render_html_response(path: &str) -> Response<Full<Bytes>> {
             current_key: None,
             part_definition_form: definy_ui::PartDefinitionFormState {
                 part_name_input: String::new(),
-                part_type_input: definy_event::event::PartType::Number,
+                part_type_input: Some(definy_event::event::PartType::Number),
                 part_description_input: String::new(),
-                composing_expression: definy_event::event::Expression::Number(definy_event::event::NumberExpression { value: 0 }),
+                composing_expression: definy_event::event::Expression::Number(
+                    definy_event::event::NumberExpression { value: 0 },
+                ),
                 eval_result: None,
             },
             part_update_form: definy_ui::PartUpdateFormState {
                 part_name_input: String::new(),
                 part_description_input: String::new(),
-                expression_input: definy_event::event::Expression::Number(definy_event::event::NumberExpression { value: 0 }),
+                expression_input: definy_event::event::Expression::Number(
+                    definy_event::event::NumberExpression { value: 0 },
+                ),
             },
             event_detail_eval_result: None,
             profile_name_input: String::new(),


### PR DESCRIPTION
## Summary
- make `PartDefinitionEvent.part_type` optional (`Option<PartType>`)
- update part definition UI/state to handle `None` and add `None` selector in root type picker
- update displays/type diagnostics to safely handle missing part type

## Validation
- `cargo check`
- `cargo run -p definy-build`

Fixes #603